### PR TITLE
fix agent 2

### DIFF
--- a/src/app/agent/page.tsx
+++ b/src/app/agent/page.tsx
@@ -145,7 +145,11 @@ export default function PageAgent() {
         subPlaceholder="Show a comprehensive overview of data from different sources."
       >
         <div className="flex items-center">
-          <Calendar className="w-[272px] h-8" />
+          <Calendar
+            className="w-[272px] h-8"
+            titleStyle="pr-0 tracking-[0.25px]"
+            iconStyle="!w-[1.25rem] !h-[1.25rem]"
+          />
         </div>
       </Header>
 
@@ -164,22 +168,22 @@ export default function PageAgent() {
                 <Panel label="Ethereum" value="25" variant="primary" />
               </div>
             </div>
-            <div className="flex flex-1 flex-row border-y border-y-gray-1 mb-[6px] rounded-b-xl p-5 gap-4">
+            <div className="flex flex-1 flex-row border-y border-y-gray-1 mb-[4px] rounded-b-xl p-5 gap-4 bg-base-bg5">
               <CardDashboard
                 placeholder={"Total Revenue"}
-                value={"Rp500.950.450,00"}
+                value={"Rp500.950.450"}
                 profit={true}
                 percentage={"23.8% (+24)"}
               />
               <CardDashboard
                 placeholder={"Ethereum Revenue"}
-                value={"Rp245.300.685,00"}
+                value={"Rp245.300.685"}
                 profit={false}
                 percentage={"-16.5% (-8)"}
               />
               <CardDashboard
-                placeholder={"Total Turn Over"}
-                value={"Rp500.950.450,00"}
+                placeholder={"Total Turnover"}
+                value={"Rp500.950.450"}
                 profit={true}
                 percentage={"23.8% (+24)"}
               />

--- a/src/components/atoms/calender/calender.tsx
+++ b/src/components/atoms/calender/calender.tsx
@@ -6,6 +6,8 @@ export const Calendar: React.FC<ICalenderProps> = ({
   name,
   placeholder,
   className,
+  titleStyle,
+  iconStyle,
   onChange,
 }) => {
   return (
@@ -16,11 +18,16 @@ export const Calendar: React.FC<ICalenderProps> = ({
       )}
     >
       <IconCalender className="pr-1" />
-      <div className="text-gray-6 lg:text-sm font-extralight pr-6">
+      <div
+        className={clsx(
+          "text-gray-6 lg:text-sm font-extralight pr-6",
+          titleStyle
+        )}
+      >
         2 December - 20 December
       </div>
       <div className="flex flex-1 justify-end">
-        <IconDropdown />
+        <IconDropdown className={iconStyle} />
       </div>
     </button>
   );

--- a/src/components/atoms/calender/types.ts
+++ b/src/components/atoms/calender/types.ts
@@ -2,5 +2,7 @@ export interface ICalenderProps {
   name?: string;
   placeholder?: string;
   className?: string;
+  titleStyle?: string;
+  iconStyle?: string;
   onChange?(value: string): void;
 }

--- a/src/components/molecules/Card/Agent/CardDashboard.tsx
+++ b/src/components/molecules/Card/Agent/CardDashboard.tsx
@@ -28,7 +28,11 @@ export const CardDashboard: React.FC<ICardDashboard> = ({
           )}
         </div>
         <div className="flex flex-row items-center gap-2">
-          <div className="flex flex-row gap-1 items-center bg-success-1 py-[2px] pl-1 pr-[6px] rounded-3xl max-w-max">
+          <div
+            className={`flex flex-row gap-1 items-center ${
+              profit ? "bg-success-1" : "bg-alert-1"
+            } py-[2px] pl-1 pr-[6px] rounded-3xl max-w-max`}
+          >
             {profit ? (
               <IconArrowUp className="text-success-10 !w-[13px] !h-[13px]" />
             ) : (

--- a/src/components/molecules/Card/CardOverview.tsx
+++ b/src/components/molecules/Card/CardOverview.tsx
@@ -18,7 +18,7 @@ export const CardOverview: React.FC<ICardOverview> = ({
         containerStyle
       )}
     >
-      <div className="flex flex-1 flex-col border-t border-gray-1 mt-[6px] bg-base-bg5 rounded-t-xl">
+      <div className="flex flex-1 flex-col border-t border-gray-1 mt-1 bg-base-bg5 rounded-t-xl">
         {customHeader ? (
           customHeader
         ) : (


### PR DESCRIPTION
Section Overview dan Ethereum Revenue
- [x] - Overlay di atas Ethereum Revenue = 4px

- [x] - bagian date picker = Letter Spacing :0.25px

- [x] - text di date picker = Padding right :0px/ di sesuaikan (karena di arrow  date pickernya sudah ada gap ke kiri)

- [x] - Arrow di date picker = W :1.25rem, H: 1.25rem

- [x] - Area kotak terluar "Total Revenue, Ethereum Revenue, Total Turnover" warna backdround dibuat sama dengan area "Ethereum revenue"(di atas)

- [x] - angka 00 di belakang (,) pertama pada nilai total Revenue di hapus

- [x] - Text "Total Turn Over" di ubah jadi "Total Turnover"

- [x] - background color persentase penurunan di buat : rgba(255, 140, 103, 0.1), di sesuaikan dengan figma

- [x] - Overlay di Bawah = 4px